### PR TITLE
Fixing function_traits for lambda

### DIFF
--- a/include/function_traits.hpp
+++ b/include/function_traits.hpp
@@ -14,7 +14,7 @@
 namespace fn_traits {
     template <typename Functor>
     struct function_traits
-        : public function_traits<decltype( Functor::operator())> {
+        : public function_traits<decltype( &Functor::operator())> {
     };
 
     template <typename R, typename... Args>


### PR DESCRIPTION
Testing this library (using gcc 4.8.4) i could not use it with lambdas.
So, i figured out (based on [this](http://stackoverflow.com/a/7943765) and [this](https://github.com/kennytm/utils/blob/master/traits.hpp)) that it was missing(i believe) a '&' on default function_traits specialization.
So, i made this pull-request.
After this change, it was working fine with lambdas.

By the way, very nice header library! (simple and useful) 
