### PR TITLE
Added 'conanfile.py' to allows use the header library from conan.io

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from conans import ConanFile
+
+class functionTraits(ConanFile):
+    name = "function_traits"
+    # the project does not have released versions specified, so generated
+    # a minimum version appended with the output of 'git describe --always'
+    version = "0.0.1-41428b4"
+    url     = "https://github.com/novacrazy/function_traits"
+    exports = ("include*")
+
+    #Header only
+    settings = None
+
+    def package(self):
+        self.copy("*", src="include", dst="include")


### PR DESCRIPTION
To easy the integration of the library with other projects that use the [conan](https://www.conan.io/) package manager, i have added a conan recipe (conanfile.py) to it. Conan docs can be found [here](http://docs.conan.io/en/latest/).

I could maintain an external repository with the recipe, but i thought that the project members can found useful keep it within the project. But if you do not want integrate it into the repository, that is ok.

*_Note *_ : In the conanfile.py i set the version to "0.0.1-41428b4", because the project does not specify an explicit release version. The version number was generated based on the commit of pull-request #1. I am submitting a separated pull-request because both changes are independent from each other. By the way, the version number can be changed to whatever you think is best (see [this tutorial](http://docs.conan.io/en/latest/packaging/creating_in.html) if you want know more).   

Hope that you find the PR useful.
